### PR TITLE
msm7x27a: init: Remove L7 entries, head and prepare to LP

### DIFF
--- a/init/init_msm7x27a-common.c
+++ b/init/init_msm7x27a-common.c
@@ -38,18 +38,29 @@
 void vendor_load_properties() {
     char gversionbb[92];
     char dversionbb[92];
+    char o_gversionbb[92];
+    char o_dversionbb[92];
     FILE *fp;
 
-    fp = popen("/system/xbin/printf $(/system/xbin/strings /dev/block/mmcblk0p12 | /system/bin/grep -e '-V10' -e '-V20' | /system/xbin/head -1)", "r");
+    fp = popen("/system/xbin/printf $(/system/xbin/strings /dev/block/mmcblk0p12 | /system/bin/grep -e '-V10' -e '-V20')", "r");
     fgets(gversionbb, sizeof(gversionbb), fp);
     pclose(fp);
     property_set("gsm.version.baseband", gversionbb);
 
-    fp = popen("/system/xbin/printf $(/system/bin/getprop gsm.version.baseband | /system/bin/grep -o -e 'E610' -e 'E612' -e 'E617' -e 'P700' -e 'P705' -e 'P708' | /system/xbin/head -1)", "r");
+    fp = popen("/system/xbin/printf $(/system/bin/getprop gsm.version.baseband | /system/bin/grep -o -e 'E610' -e 'E612' -e 'E617')", "r");
     fgets(dversionbb, sizeof(dversionbb), fp);
     pclose(fp);
     property_set("ro.product.device", dversionbb);
     property_set("ro.product.model", dversionbb);
 
-    ERROR("Found %s gsm baseband setting build properties for %s device\n", gversionbb, dversionbb);
+    if (strlen(gversionbb) == 0) {
+        property_set("gsm.version.baseband", "V20");
+        property_set("ro.product.device", "e610");
+        property_set("ro.product.model", "e610");
+    };
+
+    property_get("gsm.version.baseband", o_gversionbb);
+    property_get("ro.product.device", o_dversionbb);
+
+    ERROR("Found %s gsm baseband setting build properties for %s device\n", o_gversionbb, o_dversionbb);
 }


### PR DESCRIPTION
- based on vee3

Signed-off-by: Caio Oliveira caiooliveirafarias0@gmail.com
